### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <!-- classpath that Fitnesse uses when not starting from IDE/maven -->
         <standalone.classpath>wiki/fixtures</standalone.classpath>
         <fitnesse.port>9090</fitnesse.port>
-        <extraFailsafeListeners>,fitnesse.junit.JUnitXMLPerPageListener</extraFailsafeListeners>
+        <extraFailsafeListeners>,fitnesse.junit.JUnitXMLPerPageRunListener</extraFailsafeListeners>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This needed change in the releasenotes was not reflected in the example project
New in 4.27.0
Deprecated nl.hsac.fitnesse.junit.JUnitXMLPerPageListener use fitnesse.junit.JUnitXMLPerPageRunListener instead. This is probably a very small change to your project's pom.xml.